### PR TITLE
Use gcc builtins for firstbit/lastbit.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,17 @@ link_directories(${GTEST_LIBS_DIR})
 add_definitions ("-fPIC")
 enable_testing()
 
-include_directories(lib/)
+# check_function_exists does not work for builtins, so use try_compile.
+try_compile(HAVE_BUILTIN_BITOPS
+            "${PROJECT_BINARY_DIR}"
+            "${PROJECT_SOURCE_DIR}/TestBuiltinBitops.cpp")
+
+# Set up the configure file.
+configure_file("${PROJECT_SOURCE_DIR}/Config.h.in"
+               "${PROJECT_BINARY_DIR}/Config.h")
+
+# Also search for includes in PROJECT_BINARY_DIR to find config.h.
+include_directories(lib/ "${PROJECT_BINARY_DIR}")
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 add_subdirectory(lib/pokerstove/peval)
 add_subdirectory(lib/pokerstove/penum)

--- a/src/Config.h.in
+++ b/src/Config.h.in
@@ -1,0 +1,1 @@
+#cmakedefine HAVE_BUILTIN_BITOPS

--- a/src/TestBuiltinBitops.cpp
+++ b/src/TestBuiltinBitops.cpp
@@ -1,0 +1,7 @@
+int main (void)
+{
+    __builtin_clz(1);
+    __builtin_ctz(1);
+    __builtin_ctzll(1);
+    return 0;
+}

--- a/src/lib/pokerstove/util/lastbit.h
+++ b/src/lib/pokerstove/util/lastbit.h
@@ -1,7 +1,48 @@
 #ifndef __LASTBIT_H
 #define __LASTBIT_H
 
+#include <Config.h>
 #include <pokerstove/util/utypes.h>
+
+#ifdef HAVE_BUILTIN_BITOPS
+
+inline uint firstbit (uint64_t v)
+{
+    // __builtin_clz(0) is undefined, so don't do that.
+    if (v == 0)
+        return 0;
+    return 63 - __builtin_clzll(v);
+}
+
+inline int lastbit (uint32_t v)
+{
+    if (v == 0)
+        return 0;
+    return __builtin_ctz(v);
+}
+
+inline int lastbit (uint16_t v)
+{
+    if (v == 0)
+        return 0;
+    return __builtin_ctz(v);
+}
+
+inline int lastbit (uint64_t v)
+{
+    if (v == 0)
+        return 0;
+    return __builtin_ctzll(v);
+}
+
+inline int lastbit64 (uint64_t v)
+{
+    if (v == 0)
+        return 0;
+    return __builtin_ctzll(v);
+}
+
+#else
 
 inline uint firstbit (uint64_t v)
 {
@@ -85,5 +126,7 @@ inline int lastbit64 (uint64_t v)
  
  return r;
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
The builtins are a single instruction on x86-64.

Let me know if I should move the TestBuiltinBitops.cpp and Config.h locations.