### PR TITLE
Add possibility to create Suits from chars

### DIFF
--- a/src/lib/pokerstove/peval/Suit.cpp
+++ b/src/lib/pokerstove/peval/Suit.cpp
@@ -246,6 +246,13 @@ Suit::Suit(const std::string& str)
     : _suit(suit_code(str[0]))
 {}
 
+Suit::Suit(uint8_t c)
+{
+    if (isSuitChar(c))
+        _suit = suit_code(c);
+    else
+        _suit = c;
+}
 
 string Suit::str() const
 {

--- a/src/lib/pokerstove/peval/Suit.h
+++ b/src/lib/pokerstove/peval/Suit.h
@@ -47,7 +47,7 @@ public:
      * object to be created.
      */
     explicit Suit(const std::string& str);
-    explicit Suit(uint8_t c)     : _suit(c) {}
+    explicit Suit(uint8_t c);
 
 
     /**

--- a/src/lib/pokerstove/peval/Suit.test.cpp
+++ b/src/lib/pokerstove/peval/Suit.test.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "Suit.h"
+
+using namespace pokerstove;
+
+const char* suits = "cdhsCDHS";
+
+TEST(Suit, ConstructorChars) {
+    char suitstr[] = "?";
+
+    // test the valid char range
+    for (int i=0; i<strlen(suits); i++) {
+        Suit s(suits[i]);
+        suitstr[0] = suits[i];
+        EXPECT_STRCASEEQ(suitstr, s.str().c_str());
+    }
+}
+
+TEST(Suit, ConstructorInts) {
+    char suitstr[] = "?";
+
+    // test the valid int range
+    for (int i=0; i<=3; i++) {
+        Suit s(i);
+        suitstr[0] = suits[i];
+        EXPECT_STREQ(suitstr, s.str().c_str());
+    }
+}
+
+TEST(Suit, ConstructorErrs) {
+    char suitstr[] = "?";
+
+    // test the invalid int range
+    for (int i=4; i<'C'; i++) {
+        Suit s(i);
+        EXPECT_STREQ(suitstr, s.str().c_str());
+    }
+}


### PR DESCRIPTION
This change fixes #35 by adding the possibility to create Suits from the characters "cdhsCDHS" by adding a call to suit_code when necessary. This mirrors the functionality of Rank, where for example it is also possible to create the Rank RANK_TWO by passing the character '2' to the constructor. An appropriate test is included. 