### PR TITLE
Make ps-eval great again

### DIFF
--- a/src/programs/ps-eval/main.cpp
+++ b/src/programs/ps-eval/main.cpp
@@ -1,36 +1,79 @@
 #include <iostream>
 #include <vector>
+#include <boost/program_options.hpp>
 #include <pokerstove/penum/ShowdownEnumerator.h>
 
-int main() {
-
 using namespace pokerstove;
+namespace po = boost::program_options;
 using namespace std;
 
-CardSet completeDeck;
-completeDeck.fill();
-cout << "The whole deck has " << completeDeck.size() << " cards" << endl;
+int main(int argc, char** argv) {
+  po::options_description desc("ps-eval, a poker hand evaluator\n");
 
-CardDistribution anyTwo;
-anyTwo.fill(completeDeck, 2);
-cout << "There are " << anyTwo.size() << " two card combinations"  << endl;
+  desc.add_options()("help,?", "produce help message")
+      ("game,g", po::value<string>()->default_value("h"), "game to use for evaluation")
+      ("board,b", po::value<string>(), "community cards for he/o/o8")
+      ("hand,h", po::value<vector<string>>(), "a hand for evaluation")
+      ("quiet,q", "produces no output");
 
-CardDistribution holeCards;
-holeCards.parse("As6s");
-cout << "There are " << holeCards.size() << " two card combinations"  << endl;
+  // make hand a positional argument
+  po::positional_options_description p;
+  p.add("hand", -1);
 
-ShowdownEnumerator showdown;
-vector<EquityResult> result = showdown.calculateEquity(
-    vector<CardDistribution>{anyTwo, holeCards},
-    CardSet(""),
-    PokerHandEvaluator::alloc("h")
-);
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv)
+                .style(po::command_line_style::unix_style)
+                .options(desc)
+                .positional(p)
+                .run(),
+            vm);
+  po::notify(vm);
 
-double shareRandom = result.at(0).winShares + result.at(0).tieShares;
-double shareHand   = result.at(1).winShares + result.at(1).tieShares;
-double total       = shareRandom + shareHand;
+  // check for help
+  if (vm.count("help") || argc == 1) {
+    cout << desc << endl;
+    return 1;
+  }
 
-cout << "A random hand has "  << shareRandom / total * 100  << " % equity (" << result.at(0).str() << ")" << endl;
-cout << "The hand As6s has "  << shareHand   / total * 100  << " % equity (" << result.at(1).str() << ")" << endl;
+  // extract the options
+  string game = vm["game"].as<string>();
+  string board = vm.count("board") ? vm["board"].as<string>() : "";
+  vector<string> hands = vm["hand"].as<vector<string>>();
 
+  bool quiet = vm.count("quiet") > 0;
+
+  // allocate evaluator and create card distributions
+  boost::shared_ptr<PokerHandEvaluator> evaluator =
+      PokerHandEvaluator::alloc(game);
+  vector<CardDistribution> handDists;
+  for (const string& hand : hands) {
+    handDists.emplace_back();
+    handDists.back().parse(hand);
+  }
+
+  // fill with random if necessary
+  if (handDists.size() == 1) {
+    handDists.emplace_back();
+    handDists.back().fill(evaluator->handSize());
+  }
+
+  // calcuate the results and print them
+  ShowdownEnumerator showdown;
+  vector<EquityResult> results =
+      showdown.calculateEquity(handDists, CardSet(board), evaluator);
+
+  double total = 0.0;
+  for (const EquityResult& result : results) {
+    total += result.winShares + result.tieShares;
+  }
+
+  if (!quiet) {
+      for (size_t i = 0; i < results.size(); ++i) {
+        double equity = (results[i].winShares + results[i].tieShares) / total;
+        string handDesc =
+            (i < hands.size()) ? "The hand " + hands[i] : "A random hand";
+        cout << handDesc << " has " << equity * 100. << " % equity ("
+             << results[i].str() << ")" << endl;
+      }
+  }
 }


### PR DESCRIPTION
This change fixes issue #32 by implementing the command line
arguments ps-eval is supposed to have according to README.md. This provides
basic functionality which goes beyond a fixed As6s vs random holdem
evaluation.