### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+dist: trusty
+
+language: cpp
+
+os: linux
+
+compiler:
+    - gcc
+    - clang
+
+addons:
+    apt:
+        packages:
+            - libboost-all-dev
+
+before_script:
+    - mkdir build
+
+script:
+    - cd build
+    - cmake -DCMAKE_CXX_FLAGS='-std=c++11' -DCMAKE_VERBOSE_MAKEFILE=ON ../src
+    - make -j 2
+    - make test


### PR DESCRIPTION
This builds on Ubuntu Trusty with Clang and GCC.
Example runs: https://travis-ci.org/rakhimov/pokerstove

There are some bogus issues with '-std=c++11' flags
that needs proper CMake configurations per library.
The current setup is only provided for executables.
PR #33 seems to be related to this issue.