### PR TITLE
Enable OS X build on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ addons:
         packages:
             - libboost-all-dev
 
+matrix:
+    include:
+        - os: osx
+          compiler: clang
+          env: CONFIG=Release
+
 before_script:
     - mkdir build
 


### PR DESCRIPTION
Only Release builds are tested
since this build image is limited on Travis-CI (long queues).
Example build:
https://travis-ci.org/rakhimov/pokerstove/jobs/385825324