### PR TITLE
Build gtest along with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
 # Set up gtest. This must be set up before any subdirectories are
 # added which will use gtest.
 add_subdirectory(src/ext/googletest)
-find_library(gtest REQUIRED)
+# find_library(gtest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 link_directories(${GTEST_LIBS_DIR})
 add_definitions("-fPIC")


### PR DESCRIPTION
Rather than using `find_library`, point it to subdirectory and build.

as mentioned here:   https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project


I tried using the #75 pr from @lucasmitrik, but in my rolling arch release, the system gtest was incompatible and got a lot of errors.  

This significantly increases build time, but keeps the test dependencies pinned to whatever is in the source files, and I think should increase portability in general.