### PR TITLE
rm usage of deprecated std::binary_function

### DIFF
--- a/src/lib/pokerstove/penum/SimpleDeck.hpp
+++ b/src/lib/pokerstove/penum/SimpleDeck.hpp
@@ -22,9 +22,7 @@ namespace pokerstove
 /**
  * used for removing cards from the deck
  */
-struct isLive : public std::binary_function<pokerstove::CardSet,
-                                            pokerstove::CardSet,
-                                            bool>
+struct isLive
 {
     bool operator()(const CardSet& c, const CardSet& dead) const
     {


### PR DESCRIPTION
In c++11 or later, classes that inherit from `std::binary_function` will just work if the inheritance is removed (see discussion [here](https://stackoverflow.com/q/33114656/543913)).