### PR TITLE
Feature: Add dead cards option for evaluation

### DIFF
--- a/src/lib/pokerstove/penum/ShowdownEnumerator.cpp
+++ b/src/lib/pokerstove/penum/ShowdownEnumerator.cpp
@@ -21,6 +21,7 @@ ShowdownEnumerator::ShowdownEnumerator() {}
 
 vector<EquityResult> ShowdownEnumerator::calculateEquity(const vector<CardDistribution>& dists,
                                                          const CardSet& board,
+                                                         const CardSet& dead_cards,
                                                          boost::shared_ptr<PokerHandEvaluator> peval) const
 {
     if (peval.get() == NULL)
@@ -90,6 +91,7 @@ vector<EquityResult> ShowdownEnumerator::calculateEquity(const vector<CardDistri
         {
             deck.reset();
             deck.remove(dead);
+            deck.remove(dead_cards);
             PartitionEnumerator2 pe(deck.size(), parts);
             do
             {

--- a/src/lib/pokerstove/penum/ShowdownEnumerator.h
+++ b/src/lib/pokerstove/penum/ShowdownEnumerator.h
@@ -22,6 +22,7 @@ public:
     std::vector<EquityResult>
     calculateEquity(const std::vector<CardDistribution>& dists,
                     const CardSet& board,
+                    const CardSet& dead_cards,
                     boost::shared_ptr<PokerHandEvaluator> peval) const;
 };
 }  // namespace pokerstove

--- a/src/lib/pokerstove/peval/CardSet.cpp
+++ b/src/lib/pokerstove/peval/CardSet.cpp
@@ -151,6 +151,7 @@ void CardSet::fromString(const string& instr)
             i -= 1;
             continue;
         }
+
         int code = Rank::rank_code(instr[i]) +
                    Suit::suit_code(instr[i + 1]) * Rank::NUM_RANK;
         uint64_t mask = (ONE64 << code);

--- a/src/programs/ps-eval/main.cpp
+++ b/src/programs/ps-eval/main.cpp
@@ -16,6 +16,7 @@ int main(int argc, char** argv)
         ("game,g",  po::value<string>()->default_value("h"),    "game to use for evaluation")
         ("board,b", po::value<string>(),                        "community cards for he/o/o8")
         ("hand,h",  po::value<vector<string>>(),                "a hand for evaluation")
+        ("dead,d", po::value<string>(),                         "dead cards for evaluation")
         ("quiet,q", "produces no output");
 
     // make hand a positional argument
@@ -41,6 +42,7 @@ int main(int argc, char** argv)
     // extract the options
     string game = vm["game"].as<string>();
     string board = vm.count("board") ? vm["board"].as<string>() : "";
+    string dead = vm.count("dead") ? vm["dead"].as<string>() : "";
     vector<string> hands = vm["hand"].as<vector<string>>();
 
     bool quiet = vm.count("quiet") > 0;
@@ -65,7 +67,7 @@ int main(int argc, char** argv)
     // calcuate the results and print them
     ShowdownEnumerator showdown;
     vector<EquityResult> results =
-        showdown.calculateEquity(handDists, CardSet(board), evaluator);
+        showdown.calculateEquity(handDists, CardSet(board), CardSet(dead), evaluator);
 
     double total = 0.0;
     for (const EquityResult& result : results)


### PR DESCRIPTION
Dead cards option for evaluation in games Holdem, Omaha etc. 
Added for enabling multi-board evaluation.


I wanted this feature also on cmdline ... do you think we can merge this? ... It helps evaluate double board bomp pots