### PR TITLE
Fix unused parameter warning.

### DIFF
--- a/src/lib/pokerstove/peval/PokerHandEvaluator.h
+++ b/src/lib/pokerstove/peval/PokerHandEvaluator.h
@@ -149,7 +149,7 @@ public:
     /**
      * used to add "draws" to draw games
      */
-    virtual void setNumDraws(size_t sz)
+    virtual void setNumDraws(size_t)
     {
         throw std::runtime_error("not implemented");
     }


### PR DESCRIPTION
Hi, thanks for the excellent library,  the commit fixes a warning.

```bash
 PokerHandEvaluator.h:152:37: warning: unused parameter 'sz' [-Wunused-parameter]
```