### PR TITLE
Support for 5 card and 6 card Omaha.

### DIFF
--- a/src/lib/pokerstove/peval/PokerHandEvaluator_Alloc.cpp
+++ b/src/lib/pokerstove/peval/PokerHandEvaluator_Alloc.cpp
@@ -50,10 +50,14 @@ std::shared_ptr<PokerHandEvaluator> PokerHandEvaluator::alloc (const string & in
     {
       auto ohigh = new UniversalHandEvaluator (4,4,3,5,2,&CardSet::evaluateHigh, NULL);
       auto ohighlow8 = new UniversalHandEvaluator (4,4,3,5,2,&CardSet::evaluateHigh, NULL);
-      if (strid == "o6" || strid == "o5") {
-        ret.reset (new UniversalHandEvaluator (4,4,3,5,2,&CardSet::evaluateHigh, NULL));
-      } else if (strid == "o5/8" || strid == "o6/8") {
-        ret.reset (new UniversalHandEvaluator (4,4,3,5,2, &CardSet::evaluateHigh, &CardSet::evaluate8LowA5));
+      if (strid == "o6") {
+        ret.reset (new UniversalHandEvaluator (6,6,3,5,2,&CardSet::evaluateHigh, NULL));
+      } else if (strid == "o6/8") {
+        ret.reset (new UniversalHandEvaluator (6,6,3,5,2, &CardSet::evaluateHigh, &CardSet::evaluate8LowA5));
+      } else if (strid == "o5") {
+        ret.reset (new UniversalHandEvaluator (5,5,3,5,2,&CardSet::evaluateHigh, NULL));
+      } else if (strid == "o5/8") {
+        ret.reset (new UniversalHandEvaluator (5,5,3,5,2, &CardSet::evaluateHigh, &CardSet::evaluate8LowA5));
       } else if (strid == "o") {
         ret.reset (new OmahaHighHandEvaluator);
       } else if (strid == "o/8") {

--- a/src/lib/pokerstove/peval/PokerHandEvaluator_Alloc.cpp
+++ b/src/lib/pokerstove/peval/PokerHandEvaluator_Alloc.cpp
@@ -48,8 +48,6 @@ std::shared_ptr<PokerHandEvaluator> PokerHandEvaluator::alloc (const string & in
 
     case 'o':		//     omaha
     {
-      auto ohigh = new UniversalHandEvaluator (4,4,3,5,2,&CardSet::evaluateHigh, NULL);
-      auto ohighlow8 = new UniversalHandEvaluator (4,4,3,5,2,&CardSet::evaluateHigh, NULL);
       if (strid == "o6") {
         ret.reset (new UniversalHandEvaluator (6,6,3,5,2,&CardSet::evaluateHigh, NULL));
       } else if (strid == "o6/8") {


### PR DESCRIPTION
Hello Andrew et al.

I was trying to add support for 6 card Omaha, but I found out that there was already support for it. However it seemed to be incomplete.

The pseudo-switch statements first bundle o5 and o6, and then they set the amount of pocket cards to 4, effectively making it 4card omaha.

I believe this fixes it and implements the capacity to evaluate 6 and 5 card omaha, hi and lo.

Additionally, I removred some unused lines, presumably during an attempt to migrate from a hard coded omaha evaluator to a universal evaluator. Altough the jump was never made.

I chose not to use the Universal version in Omaha 4, so as to avoid breaking changes, but this Universal version is used for 5 and 6 card of course, which naturally provides a testing phase before it would get implemented for Omaha 4.

No tests are added, but there's definitely room. It's worth noting that there were tests for O5 and O6, but this issue was not caught because the tests use the evaluation functions directly instead of the command line. And the bug is present in the Alloc.cpp file which presumably allocates evaluation functions to command line options.

